### PR TITLE
Renamed containers

### DIFF
--- a/deployment.en.md
+++ b/deployment.en.md
@@ -69,7 +69,7 @@ export const endpoints = {
 
 In the `docker-compose-dev.yaml` file, you will find two services with their respective configurations:
 
-- **aiod-marketplace-frontend**: This service runs a Node.js server that launches the Angular application on port 8080.
+- **mylibrary-frontend**: This service runs a Node.js server that launches the Angular application on port 8080.
 - **proxy**: It uses Nginx as a reverse proxy for the necessary API REST. Configure the environment variables to identify where the API RESTs are running, such as `MY_PATH_API_AIOD_CATALOGUE` and `MY_PATH_API_MY_LIB`.
 
 To start the Docker services, use the following command:
@@ -134,7 +134,7 @@ export const environment = {
 
 In the `docker-compose.yaml` file, you will find a service with its respective configuration:
 
-- **nginx-marketplace-frontend**: This service uses Nginx as a reverse proxy for the necessary API RESTs and as a web server for the Angular application. Configure environment variables, such as `MY_PATH_API_AIOD_CATALOGUE` and `MY_PATH_API_MY_LIB`.
+- **mylibrary-nginx-frontend**: This service uses Nginx as a reverse proxy for the necessary API RESTs and as a web server for the Angular application. Configure environment variables, such as `MY_PATH_API_AIOD_CATALOGUE` and `MY_PATH_API_MY_LIB`.
 
 >NOTE:
 >

--- a/deployment.es.md
+++ b/deployment.es.md
@@ -134,7 +134,7 @@ export const environment = {
 3. **Configurar y Ejecutar el Servicio de Docker Compose**
 En el archivo` docker-compose.yaml`, encontrarás un servicio con sus respectivas configuraciones:
 
-- **nginx-marketplace-frontend**: Este servicio utiliza Nginx como un proxy inverso para los API REST necesarios y como servidor web para la aplicación Angular. Configura las variables de entorno, como `MY_PATH_API_AIOD_CATALOGUE` y `MY_PATH_API_MY_LIB`.
+- **mylibrary-nginx-frontend**: Este servicio utiliza Nginx como un proxy inverso para los API REST necesarios y como servidor web para la aplicación Angular. Configura las variables de entorno, como `MY_PATH_API_AIOD_CATALOGUE` y `MY_PATH_API_MY_LIB`.
 
 >NOTE:
 >

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,8 +1,8 @@
 version: '3.8'
 
 services:
-  aiod-marketplace-frontend:
-    container_name: aiod_marketplace_frontend
+  mylibrary-frontend:
+    container_name: mylibrary-frontend
     build:
       context: .
       dockerfile: docker/marketplace/dev/Dockerfile
@@ -13,7 +13,7 @@ services:
     ports:
     - 9092:8080
   proxy:
-    container_name: ngix-proxy
+    container_name: nginx-proxy
     image: nginx
     environment:
       - MY_PATH_API_AIOD_CATALOGUE=https://aiod-dev.i3a.es

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3.8'
 
 services:
-  nginx-marketplace-frontend:
-    container_name: nginx-marketplace-frontend
+  mylibrary-nginx-frontend:
+    container_name: mylibrary-nginx-frontend
     build:
       context: .
       dockerfile: docker/marketplace/prod/Dockerfile

--- a/src/environments/endpoints.ts
+++ b/src/environments/endpoints.ts
@@ -12,7 +12,7 @@ export const endpoints = {
 
     //Payments
     prefixApiPayment: '/api-library/api',
-    payment: '/libraries/:userId/purchases',
+    payment: '/libraries/:userId/assets',
 
     //My-library
     prefixApiLibraries: '/api-library/api',


### PR DESCRIPTION
This PR renames some Docker containers and applies renaming of MyLibrary Backend endpoint `POST /libraries/{id_user}/purchases`  TO `POST /libraries/{id_user}/assets`  (applied in that project in [this PR](https://github.com/aiondemand/AIOD-mylibrary-backend/pull/3)).