### PR TITLE
Renamed asset distributions property to distribution

### DIFF
--- a/src/app/modules/marketplace/components/asset-detail/asset-detail.component.html
+++ b/src/app/modules/marketplace/components/asset-detail/asset-detail.component.html
@@ -230,13 +230,24 @@
           }}</span>
           <span>: {{ distribution.size }}</span>
         </p>
-        <p *ngIf="!!distribution.url">
+        <p *ngIf="!!distribution.content_url && distribution.content_url.length > 0">
           <span class="distribution-title">{{
-            "ASSETS.DISTRIBUTION.URL" | translate
+            "ASSETS.DISTRIBUTION.CONTENT_URL" | translate
           }}</span>
           <span
             >:
-            <a [href]="distribution.url" target="_blank">{{
+            <a [href]="distribution.content_url" target="_blank">{{
+              distribution.url
+            }}</a>
+          </span>
+        </p>
+        <p *ngIf="!!distribution.encoding_format && distribution.encoding_format.length > 0">
+          <span class="distribution-title">{{
+            "ASSETS.DISTRIBUTION.ENCODING_FORMAT" | translate
+          }}</span>
+          <span
+            >:
+            <a [href]="distribution.encoding_format" target="_blank">{{
               distribution.url
             }}</a>
           </span>
@@ -246,6 +257,12 @@
             "ASSETS.DISTRIBUTION.CHECKSUM" | translate
           }}</span>
           <span>: {{ distribution.checksum }} </span>
+        </p>
+        <p *ngIf="!!distribution.checksum_algorithm && distribution.checksum_algorithm.length > 0">
+          <span class="distribution-title">{{
+            "ASSETS.DISTRIBUTION.CHECKSUM_ALGORITHM" | translate
+          }}</span>
+          <span>: {{ distribution.checksum_algorithm }} </span>
         </p>
       </div>
     </mat-card-content>

--- a/src/app/modules/marketplace/components/asset-detail/asset-detail.component.ts
+++ b/src/app/modules/marketplace/components/asset-detail/asset-detail.component.ts
@@ -50,7 +50,6 @@ export class AssetDetailComponent implements OnInit, OnDestroy{
         this.asset = asset;
         this.breadcrumbService.set('@assetName', this.asset.name)
         this.isLoading = false;
-        // console.log  ('Asset', this.asset)
       },
       error: (error: any) => {
         setTimeout(() => (this.isLoading = false), 3000)

--- a/src/app/shared/models/asset.model.ts
+++ b/src/app/shared/models/asset.model.ts
@@ -34,7 +34,7 @@ export class AssetModel {
         this.scientific_domain = data.scientific_domain;
         this.research_area = data.research_area;
         this.date_published = data.date_published;
-        this.distributions = data.distributions;
+        this.distributions = data.distribution;
         this.alternateName = data.alternateName;
         this.media = data.media?.map((dataMedia: any) => new Media(dataMedia));
         this.version = data.version;

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -133,7 +133,10 @@
             "DESCRIPTION": "Description",
             "SIZE": "Size",
             "URL": "URL",
-            "CHECKSUM": "Checksum"
+            "CHECKSUM": "Checksum",
+            "CHECKSUM_ALGORITHM": "Checksum Algorithm",
+            "CONTENT_URL": "URL",
+            "ENCODING_FORMAT": "Encoding Format"
         },
         "MEDIA": {
             "TITLE": "Media",


### PR DESCRIPTION
## Change
Asset model retrieves distributions information from the "distribution" property of the data received from the REST API. The asset detail template includes now some distribution's property that were not previously included.


## How to Test
Go to: http://localhost:9092/resources/45080?category=Dataset
and check that distribution information is shown for asset with identifier 45080 in dev instance of REST API.
 
![Captura de pantalla de 2025-05-17 00-14-24](https://github.com/user-attachments/assets/0d12b964-b6d9-498b-b699-0940e5447a26)
