### PR TITLE
bug(ui): category not preserved when navigating between screens

### DIFF
--- a/src/app/modules/marketplace/components/assets-list/assets-list.component.ts
+++ b/src/app/modules/marketplace/components/assets-list/assets-list.component.ts
@@ -111,6 +111,14 @@ export class AssetsListComponent implements OnInit, OnDestroy {
           this.isEnhancedSearch = value;
         },
       });
+    
+    const selectedCategory = localStorage.getItem("selectedCategory");
+    if(selectedCategory && this.isValidAssetCategory(selectedCategory)) {
+      this.categorySelected = selectedCategory as AssetCategory;
+      this.selectCat(this.categorySelected);
+    }
+
+
 
     this.filtersStateService.searchQuery$
       .pipe(takeUntil(this.destroy$))
@@ -148,6 +156,7 @@ export class AssetsListComponent implements OnInit, OnDestroy {
   }
   protected selectCat(category: AssetCategory) {
     this.categorySelected = category;
+    localStorage.setItem("selectedCategory", category)
     this.filtersService.setAssetCategorySelected(this.categorySelected);
   }
   protected unSelectCat(id: number) {


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->
The selected category is now stored in local storage to persist its value across screens during the user session.
## How to Test
<!-- Describe a way to test the change of this PR -->
Select any category.

Navigate to a different screen.

Return to the asset-list screen.

Verify that the previously selected category is still active.



## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->
Closes #29 

