### PR TITLE
fix: force index.html to not get cached

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -26,7 +26,7 @@ http {
 
     server {
         listen 80;
-
+        root   /usr/share/nginx/html;
         add_header 'Access-Control-Allow-Origin' * always;
         add_header 'Access-Control-Allow-Methods' "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS" always;
         add_header 'Access-Control-Allow-Credentials' "true" always;
@@ -43,7 +43,6 @@ http {
             add_header Pragma "no-cache" always;
             add_header Expires "0" always;
             expires -1;
-            root   /usr/share/nginx/html;
             try_files $uri =404;
         }
 
@@ -56,7 +55,7 @@ http {
 
           
     location / {
-        root   /usr/share/nginx/html;
+      
         try_files $uri $uri/ /index.html;
         index  index.html index.htm;
     }


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->

All production build types were already hashed :
<img width="1275" height="709" alt="image" src="https://github.com/user-attachments/assets/45aebe0a-8361-4ef4-8093-b425c307c43f" />

so the only possible approach is to force index.html(were the bundles are charged) to never be cached 

## Change
<!-- Briefly describe the change of this PR -->


## How to Test
<!-- Describe a way to test the change of this PR -->

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->

closes #148 
