### PR TITLE
fix: asset category missing #165

### DIFF
--- a/src/app/modules/marketplace/components/assets-list/assets-list.component.ts
+++ b/src/app/modules/marketplace/components/assets-list/assets-list.component.ts
@@ -262,7 +262,10 @@ export class AssetsListComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (resp: SearchModel) => {
           this.isLoading = false;
-          this.assets = resp.resources;
+          this.assets = resp.resources.map((asset) => ({
+            ...asset,
+            category: this.categorySelected,
+          }));
           this.assetsSize = resp.totalHits;
         },
         error: (error: any) => {
@@ -292,7 +295,10 @@ export class AssetsListComponent implements OnInit, OnDestroy {
     const subscribe = serviceObs.subscribe({
       next: (assets: AssetModel[]) => {
         this.isLoading = false;
-        this.assets = assets;
+        this.assets = assets.map((asset) => ({
+          ...asset,
+          category: this.categorySelected,
+        }));
       },
       error: (error: any) => {
         // this.assets bellow might be used for testing purposes
@@ -682,7 +688,10 @@ export class AssetsListComponent implements OnInit, OnDestroy {
       )
       .subscribe({
         next: (assets: any[]) => {
-          this.assets = assets;
+          this.assets = assets.map((asset) => ({
+            ...asset,
+            category: this.categorySelected,
+          }));
           this.assetsSize = assets.length;
           this.spinnerService.hide();
         },


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->
When the refactor https://github.com/aiondemand/AIOD-marketplace-frontend/pull/121/ of the dataset logic was made, enhanced search logic was not considered, this ensures that the asset category is used in the router param when clicking asset card.


## How to Test
<!-- Describe a way to test the change of this PR -->

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


