### PR TITLE
Fix display of enhanced search results

### DIFF
--- a/src/app/modules/marketplace/components/assets-list/assets-list.component.ts
+++ b/src/app/modules/marketplace/components/assets-list/assets-list.component.ts
@@ -659,7 +659,7 @@ export class AssetsListComponent implements OnInit, OnDestroy {
           if (
             response.status === 'Completed' &&
             (!response.results ||
-              (!response.results && response.results.length == 0))
+              (response.results && response.results.length == 0))
           ) {
             this.spinnerService.updateMessage('No results found.');
             return of({ result_asset_ids: [] });

--- a/src/app/modules/marketplace/components/assets-list/assets-list.component.ts
+++ b/src/app/modules/marketplace/components/assets-list/assets-list.component.ts
@@ -637,8 +637,7 @@ export class AssetsListComponent implements OnInit, OnDestroy {
           );
         }),
         filter(
-          (response) =>
-            response.status === 'Completed' && !!response.result_asset_ids,
+          (response) => response.status === 'Completed' && !!response.results,
         ),
         switchMap((response) => {
           if (
@@ -657,12 +656,15 @@ export class AssetsListComponent implements OnInit, OnDestroy {
             );
           }
 
-          if (response.status === 'Completed' && !response.result_asset_ids) {
+          if (
+            response.status === 'Completed' &&
+            (!response.results ||
+              (!response.results && response.results.length == 0))
+          ) {
             this.spinnerService.updateMessage('No results found.');
             return of({ result_asset_ids: [] });
           }
-
-          if (response.status === 'Completed' && response.result_asset_ids) {
+          if (response.status === 'Completed' && response.results.length > 0) {
             this.spinnerService.updateMessage('Loading results...');
             return of(response);
           }
@@ -671,13 +673,12 @@ export class AssetsListComponent implements OnInit, OnDestroy {
         }),
         take(1),
         switchMap((response) => {
-          if (
-            response.result_asset_ids &&
-            response.result_asset_ids.length > 0
-          ) {
-            return this.generalAssetService.getMultipleAssets(
-              response.result_asset_ids,
+          if (response.results && response.results.length > 0) {
+            const asset_ids = response.results.map(
+              (item: { asset_id: string }) => item.asset_id,
             );
+
+            return this.generalAssetService.getMultipleAssets(asset_ids);
           }
 
           return of([]);


### PR DESCRIPTION
## Change
Adapted code to response format of request to get the query results ( GET `/v2/query/{query_id}/result`).  
V1 had a property called `result_asset_ids`, an array collecting the identifiers of the assets returned by the query. However, now, that property does not longer exist and has been replaced by this one:

```
  "results": [
    {
      "asset_id": "string",
      "asset_type": "datasets",
      "asset": {}
    }
  ],
```

## How to Test
Search word "covid", with the enhanced search checkbox checked. 
Check the results contain word "covid", and do not corresponds to the ones shown by default.

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [X] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ X] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
Related to issue #95, complements PR [#143](https://github.com/aiondemand/AIOD-marketplace-frontend/pull/143), which was already merged into staging and main (we did not notice it was not working well).

