### PR TITLE
fix(assets-list): making paginator selector visible on ligth theme

### DIFF
--- a/src/app/modules/marketplace/components/assets-list/assets-list.component.scss
+++ b/src/app/modules/marketplace/components/assets-list/assets-list.component.scss
@@ -260,9 +260,21 @@
           color: #212529 !important;
         }
       }
+
+      .nav-button{
+           color: #0047bb;
+           
+        &:disabled {
+          color: #cccccc;
+        }
+      }
+
+      
     }
 
     .paginator-right {
+
+      
       .range-label {
         color: #212529 !important;
       }
@@ -300,6 +312,15 @@
         color: #212529 !important;
       }
     }
+
+        .nav-button{
+           color: #0047bb;
+           
+        &:disabled {
+          color: #cccccc;
+        }
+      }
+    
   }
 
   .paginator-right {
@@ -307,12 +328,13 @@
       color: #212529 !important;
     }
 
-    .nav-button {
-      color: rgba(255, 237, 0, 1);
-
-      &:disabled {
-        color: #cccccc;
+    .nav-button{
+           color: #0047bb;
+           
+        &:disabled {
+          color: #cccccc;
+        }
       }
     }
-  }
+  
 }


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->


## How to Test
<!-- Describe a way to test the change of this PR -->

Just navigating through the different pages on the assets viewer. Verifying that the change is working as well in dark-theme, should be convenient.
<img width="563" height="145" alt="image" src="https://github.com/user-attachments/assets/ad77aa29-c7fb-4ffb-85f6-409e30566025" />

<img width="563" height="124" alt="image" src="https://github.com/user-attachments/assets/25481cb9-4650-4bfa-8e05-5e0ed1779040" />


## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->

closes #196 