### PR TITLE
Feat/show ai4europe cms platform 223

### DIFF
--- a/src/app/modules/marketplace/components/assets-list/assets-list.component.ts
+++ b/src/app/modules/marketplace/components/assets-list/assets-list.component.ts
@@ -33,12 +33,7 @@ import { PlatformService } from '../../services/common-services/platform.service
 import { AuthService } from '@app/core/services/auth/auth.service';
 
 const MAX_ATTEMPTS = 15;
-const EXCLUDED_PLATFORMS = [
-  'example',
-  'ai4experiments',
-  'aibuilder',
-  'ai4europe_cms',
-];
+const EXCLUDED_PLATFORMS = ['example', 'ai4experiments', 'aibuilder'];
 const assetCategoryMapping = {
   [AssetCategory.AIModel]: 'ml_models',
   [AssetCategory.Dataset]: 'datasets',

--- a/src/app/shared/models/modelConfig.ts
+++ b/src/app/shared/models/modelConfig.ts
@@ -51,7 +51,13 @@ export const modelConfig = {
     title: 'Dataset',
   },
   Experiment: {
-    columns: [...commonColumns, ...distributionColumns, ...mediaColumns, 'execution_settings', 'badge'],
+    columns: [
+      ...commonColumns,
+      ...distributionColumns,
+      ...mediaColumns,
+      'execution_settings',
+      'badge',
+    ],
     title: 'Experiment',
   },
   'Educational resource': {
@@ -67,7 +73,12 @@ export const modelConfig = {
     title: 'Educational Resource',
   },
   Publication: {
-    columns: [...commonColumns, ...distributionColumns, ...mediaColumns, 'type'],
+    columns: [
+      ...commonColumns,
+      ...distributionColumns,
+      ...mediaColumns,
+      'type',
+    ],
     title: 'Publication',
   },
   'Case studies': {


### PR DESCRIPTION
## Change
"ai4europe_cms" has been removed from "excluded_platforms" array, which contains the name of the platforms that are returned by the REST API but do not need to be visible.

Platform "ai4europe_cms" needs to be removed from that array because is the one associated to the assets that will be migrated from the old platform. 


## Related Issues
https://github.com/aiondemand/AIOD-marketplace-frontend/issues/223


## Additional notes
PR https://github.com/aiondemand/AIOD-marketplace-frontend/pull/224 was accidentally merged into `main`instead of `staging`.

