### PR TITLE
Fix/bookmarking 240: fixed value of urlMetadata param when same_as is not defined and defined tag colors

### DIFF
--- a/src/app/modules/marketplace/components/asset-detail/asset-detail.component.ts
+++ b/src/app/modules/marketplace/components/asset-detail/asset-detail.component.ts
@@ -161,7 +161,7 @@ export class AssetDetailComponent implements OnInit, OnDestroy {
       identifier: '' + this.asset.identifier,
       name: this.asset.name,
       category: this.category,
-      urlMetadata: this.asset.same_as,
+      urlMetadata: this.asset.same_as ?? '',
       price: 0,
       addedAt: new Date().getDate(),
     } as AssetsPurchase;

--- a/src/app/modules/marketplace/components/assets-list/asset-card/asset-card.component.ts
+++ b/src/app/modules/marketplace/components/assets-list/asset-card/asset-card.component.ts
@@ -47,7 +47,7 @@ export class AssetCardComponent implements OnInit {
       identifier: '' + this.asset.identifier,
       name: this.asset.name,
       category: this.asset.category,
-      urlMetadata: this.asset.same_as,
+      urlMetadata: this.asset.same_as ?? '',
       price: 0,
       addedAt: new Date().getDate(),
     } as AssetsPurchase;

--- a/src/app/modules/my-library/components/my-list/my-list.component.html
+++ b/src/app/modules/my-library/components/my-list/my-list.component.html
@@ -42,7 +42,9 @@
 
     <!-- Link Column -->
     <ng-container matColumnDef="urlMetadata">
-      <th mat-header-cell *matHeaderCellDef></th>
+      <th mat-header-cell *matHeaderCellDef>
+        {{ 'MY-LIBRARY.DISPLAY-COLUMNS.LINK' | translate }}
+      </th>
       <td mat-cell *matCellDef="let asset">
           <a
           *ngIf="!!asset.urlMetadata"

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -41,7 +41,15 @@
         },
         "publication": {
             "icon":"book",
-            "color":"#FCDFDC"
+            "color":"#D8FFE9"
+        },
+        "success stories": {
+            "icon":"book",
+            "color":"#9ECFE8"
+        },
+        "resource bundle": {
+            "icon":"book",
+            "color":"#E68270"            
         }
     }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -208,7 +208,7 @@
       "NAME": "Name",
       "CATEGORY": "Category",
       "PRICE": "Price",
-      "LINK": "URL Metadata",
+      "LINK": "Source link",
       "ACTIONS": "Delete"
     }
   },


### PR DESCRIPTION
## Change
1. If metadata property `same_as` is not defined, then url_metadata='', since this property is not actually needed in the backend side.  This fix now allows to bookmark publications, which was not working properly in the previous version. 

2. Furthermore , I have defined colors for the tag showing the category in "My bookmarks". This color was not defined for "resource bundles" and "success stories".


## How to Test

1. Login
2. From the asset list view, select asset category "Publication"
3. Click on bookmark icon

Alternatively:
3.  Click on a publication card
4. From the asset's detail view, click on bookmark icon


## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ X] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
#240


