### PR TITLE
fix: prevent redirection when user clicks on bookmark icon

### DIFF
--- a/src/app/modules/marketplace/components/assets-list/asset-card/asset-card.component.html
+++ b/src/app/modules/marketplace/components/assets-list/asset-card/asset-card.component.html
@@ -50,6 +50,7 @@ product-list-developer-card
       >
         <div
           (click)="onClickBookmark(); $event.stopPropagation()"
+          (mousedown)="$event.stopPropagation()"
           class="btn btn-circle not-rotate ml-2"
           [ngClass]="isBookmarked ? 'btn-circle--yellow' : 'btn-circle--blue'"
         >


### PR DESCRIPTION
## Change
Stopped propagation on mousedown in the "bookmark" icon in the main view. 
This avoids redirection to the asset detail view and allows adding the asset to bookmarks.
 