### PR TITLE
fix: used case_studies prefix for success stories  ai mode search

### DIFF
--- a/src/app/modules/marketplace/components/assets-list/assets-list.component.ts
+++ b/src/app/modules/marketplace/components/assets-list/assets-list.component.ts
@@ -54,7 +54,7 @@ const assetCategoryMapping = {
   [AssetCategory['Publication']]: 'publications',
   [AssetCategory['Resource Bundle']]: 'resource_bundles',
   [AssetCategory['Service']]: 'services',
-  [AssetCategory['Success stories']]: 'success_stories',
+  [AssetCategory['Success stories']]: 'case_studies',
 };
 
 @Component({


### PR DESCRIPTION
 ## Change
Renamed success stories enhanced search endpoint to "case_studies"