### PR TITLE
 Wrong button colors

### DIFF
--- a/src/app/modules/marketplace/components/asset-detail/asset-detail.component.scss
+++ b/src/app/modules/marketplace/components/asset-detail/asset-detail.component.scss
@@ -31,8 +31,7 @@ ul {
 }
 
 .btn-default:hover{
-
-background-color: #0047bb;
+  background-color: #0047bb;
 }
 .btn-success .btn-success--blue {
   cursor: default;

--- a/src/styles/base/_buttons.scss
+++ b/src/styles/base/_buttons.scss
@@ -306,8 +306,7 @@
 
   &:hover,
   &:focus,
-  &:active {
-   
+  &:active {   
       @if $buttonSuccessBorder !=0 {
         border: $buttonSuccessBorderHover;
       }
@@ -315,9 +314,6 @@
       color: $white;
       border-color: $white;
       background-color: transparent !important;
-
-      
-    
   }
 
   
@@ -593,8 +589,6 @@
   .btn-success{
  &:hover,
     &.active {
-
-     
       border-color: #0047bb;
     }
 


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->

Now hovering over the type of asset button hasn't any effect, avoiding user confusions

<img width="572" height="638" alt="image" src="https://github.com/user-attachments/assets/f28b8d8a-eba8-4fef-84b3-336c17fe02c7" />

<img width="572" height="638" alt="image" src="https://github.com/user-attachments/assets/bd29be1f-9de2-4d3c-9367-2b0579d6fade" />


## How to Test
<!-- Describe a way to test the change of this PR -->

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->

Closes #305 
