### PR TITLE
fix: check user is authenticated before requesting bookmarks

### DIFF
--- a/src/app/modules/marketplace/components/asset-detail/asset-detail.component.ts
+++ b/src/app/modules/marketplace/components/asset-detail/asset-detail.component.ts
@@ -59,6 +59,9 @@ export class AssetDetailComponent implements OnInit, OnDestroy {
         this.breadcrumbService.set('@assetName', this.asset.name);
         this.isLoading = false;
         this.prepareGenericData();
+
+        if (!this.authService.isAuthActiveUser()) return;
+
         // After asset is loaded, check if it's bookmarked
         const bookmarkSub = this.bookmarkService.getBookmarksList().subscribe({
           next: (bookmarks: AssetsPurchase[] | any) => {
@@ -107,7 +110,7 @@ export class AssetDetailComponent implements OnInit, OnDestroy {
   }
 
   protected onClickBookmark(): void {
-    if (!this.isAuthenticated()) return;
+    if (!this.authService.isAuthActiveUser()) return;
 
     if (!this.isBookmarked) {
       this.addBookmark();
@@ -143,11 +146,11 @@ export class AssetDetailComponent implements OnInit, OnDestroy {
   }
 
   isAuthenticated(): boolean {
-    return this.userProfile && Object.keys(this.userProfile).length > 0;
+    return this.authService.isAuthActiveUser();
   }
 
   private addBookmark() {
-    if (this.userProfile) {
+    if (this.authService.isAuthActiveUser()) {
       const bookmarkedAsset = this.getBookmarkedAsset();
 
       this.bookmarkService.addBookmark(bookmarkedAsset.identifier).subscribe({
@@ -160,7 +163,7 @@ export class AssetDetailComponent implements OnInit, OnDestroy {
   }
 
   private deleteBookmark() {
-    if (this.userProfile) {
+    if (this.authService.isAuthActiveUser()) {
       this.bookmarkService
         .deleteBookmark(this.asset.identifier.toString())
         .subscribe({


### PR DESCRIPTION
## Change
In asset detail view, avoid erquesting bookmarks if user is not authenticated.


## How to Test
* Make sure you are not authenticated
* Navigate to an asset detail view.

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ X] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
 Closes #316
